### PR TITLE
Allow for configurable text encoding

### DIFF
--- a/paracon/paracon.def
+++ b/paracon/paracon.def
@@ -1,5 +1,6 @@
 [Setup]
 port = 8000
+encoding = utf-8,cp437
 
 [Connect]
 port = 0


### PR DESCRIPTION
This PR allows the text encoding format to be configured by the user. Multiple encodings can be specified and separated with a comma. Paracon will try each encoding in the order specified.

I've kept the default value as utf-8 and added a fallback to [code page 437](https://en.wikipedia.org/wiki/Code_page_437) (old BBS-style 8-bit ASCII graphics) if utf-8 fails. If neither encoding works, there is a final fallback to utf-8 with the offending characters substituted with the replacement character (�).

Here is an example with just `utf-8` used for the encoding. The final fallback, including replacement characters, takes place avoiding an unhandled exception:

```
CIRCUIT
              �����������������������100R��<+12V
Wire  \�/    68K   �               �
Aerial �      �  �/            u1 ===
       ���Ĵ����ĴBC108            �
        100pF    �\e               � 
                   �        10n    �
                 470R<���Ĵ����Ŀ  �
```

And here is an example with the encoding set to `utf-8,cp437`:

```
CIRCUIT
              ┌────┬───────────────┬─100R──<+12V
Wire  \│/    68K   │               │
Aerial │      │  │/            u1 ===
       └───┤├─┴──┤BC108            │
        100pF    │\e               │ 
                   │        10n    │
                 470R<────┤├────┐  │
```

Fixes #10 