### PR TITLE
Installation and Platform-specific Paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,4 @@ docs/_build/
 dist/
 _zipapp/
 paracon*.pyz
-paracon.cfg
-*.log
 .python-version

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
+build/
+paracon.egg-info/
 .tox/
 docs/_build/
 dist/

--- a/build_zipapp.sh
+++ b/build_zipapp.sh
@@ -8,17 +8,13 @@ rm -rf $APPDIR
 mkdir -p $APPDIR
 
 # Application sources
-cp -p paracon/*.py $APPDIR/
-
-# Default config
-mkdir -p $APPDIR/paracon_config
-cp -p paracon/*.def $APPDIR/paracon_config/
-# Create empty file to make it a module
-touch $APPDIR/paracon_config/__init__.py
+mkdir $APPDIR/paracon
+cp -p paracon/*.py $APPDIR/paracon
+cp -p paracon/paracon.def $APPDIR/paracon
 
 # Install dependencies
-python -m pip install -r requirements-zipapp.txt --target $APPDIR/
+python3 -m pip install -r requirements-zipapp.txt --target $APPDIR/
 
 # Build the zipapp and make it executable
-python -m zipapp $APPDIR/ -p '/usr/bin/env python3' -o paracon_${VER}.pyz -m "paracon:run"
+python3 -m zipapp $APPDIR/ -p '/usr/bin/env python3' -o paracon_${VER}.pyz -m "paracon.paracon:run"
 chmod a+x paracon_${VER}.pyz

--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -191,20 +191,20 @@ Paracon will remember the information you enter in the Setup, Connect and
 Unproto Dest/Src dialogs. When you bring up one of these dialogs, it will
 initially show whatever values you had last entered.
 
-These settings are saved in a text file named `paracon.cfg` in your current
-directory when you started Paracon. Should you get into a confused state at
+These settings are saved in a text file named `paracon/paracon.cfg` in your
+user's configuration directory. You can see the exact path Paracon uses by using the `--help` option. Should you get into a confused state at
 any time, you may simply delete this file. The next time you start Paracon,
 it will start fresh with the Setup dialog.
 
 If you need to maintain multiple Paracon configurations - perhaps different
 setups for different servers, for example - you can do so simply by starting
-Paracon from a different directory for each configuration.
+Paracon with the `-c` option.
 
 Logging
 -------
 
-Paracon maintains a number of log files in the same directory as the Paracon
-.pyz file.
+Paracon maintains a number of log files in your user's log directory. You can
+see exactly what this log directory is by using the `--help` option.
 
 paracon.log
    Contains information about any errors that have occurred during the
@@ -218,3 +218,5 @@ monitor.log
    Contains the exchange that occurs during a connection between the two
    stations of the filename. This is the same information that you see in the
    connection tab during a connected-mode session.
+
+You can specify an alternate directory for logging with the `--log-dir` option.

--- a/paracon/config.py
+++ b/paracon/config.py
@@ -36,7 +36,7 @@ class Config:
         self.changed_sections = set()
         self.load_config()
 
-    def load_config(self):
+    def load_config(self, filepath=None):
         self.default_cfg = configparser.ConfigParser()
         if self.package:
             data = importlib.resources.read_text(
@@ -48,6 +48,9 @@ class Config:
                 self.fileroot + '.def',
             )
             self.default_cfg.read(defaults_path)
+
+        if filepath is not None:
+            self.filepath = pathlib.Path(filepath)
 
         self.user_cfg = configparser.ConfigParser()
         if self.filepath.exists():

--- a/paracon/paracon.py
+++ b/paracon/paracon.py
@@ -18,9 +18,9 @@ import urwid
 
 import ax25
 import ax25.netrom
-import config
-import pserver
-import urwidx
+import paracon.config as config
+import paracon.pserver as pserver
+import paracon.urwidx as urwidx
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -1464,7 +1464,7 @@ class UnprotoDialog(urwidx.FormDialog):
 # use when the application is packaged as a zipapp. The usual __main__ form
 # applies when running the code outside of a zipapp, during development.
 
-config = config.Config('paracon', 'paracon_config')
+config = config.Config('paracon', package='paracon')
 config.load_config()
 app = Application()
 

--- a/requirements-zipapp.txt
+++ b/requirements-zipapp.txt
@@ -1,4 +1,4 @@
 pyham_ax25
 pyham_pe
 urwid
-
+platformdirs

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,14 @@ zip_safe = True
 packages = paracon
 platforms = any
 python_requires = >= 3.7
+install_requires =
+    pyham_ax25
+    pyham_pe
+    urwid
+
+[options.package_data]
+paracon = paracon.def
+
+[options.entry_points]
+console_scripts =
+    paracon = paracon.paracon:run

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires =
     pyham_ax25
     pyham_pe
     urwid
+    platformdirs
 
 [options.package_data]
 paracon = paracon.def

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Hello! I'm playing around with Paracon, and I've made a few changes to make it more comfortable for me to use. These are basically opinions, but I thought I might open a PR for them in case you share my opinions :P.

This PR changes two things. If you end up wanting one but not the other, I can open a new PR with only those changes. If you want neither, that's fine too.

 * **Make Paracon installable.** I reorganized it into a single package and added a stub *setup.py* so that you can *pip install* this package and have it put *paracon* on the PATH. For me, this means I can use:
   ~~~~~
   pipx install "git+https://github.com/agrif/paracon@install-and-paths"
   ~~~~~
   to have *pipx* create a virtualenv and put *paracon* into it. The released zipapp is nice, but this works better for me. I updated the zipapp build to make sure it still works, too.

 * **Use user config and log directories.** On my Mac, that means putting the config file at *~/Library/Application Support/paracon/paracon.cfg* and the log files in *~/Library/Logs/paracon*. I used the *platformdirs* package to do this, which should do the right thing on Windows and Linux as well.
   
   This comes with two command line options *-c*/*--config* and *--log-dir* to override these locations. *--help* will show, explicitly, what the default paths are for users. I've updated the documentation to reflect this.

   I just find this cleaner than littering whatever directory I happen to be in when I launch *paracon*, especially if it's installed onto my PATH.